### PR TITLE
Update EKS version in KEDA sample application

### DIFF
--- a/scaling-with-KEDA/templates/eks-cluster-config.yaml
+++ b/scaling-with-KEDA/templates/eks-cluster-config.yaml
@@ -4,7 +4,7 @@ kind: ClusterConfig
 metadata:
   name: {{CW_KEDA_CLUSTER}}
   region: {{CW_AWS_REGION}}
-  version: '1.21'
+  version: '1.25'
 
 availabilityZones: ["{{CW_AWS_REGION}}a", "{{CW_AWS_REGION}}b", "{{CW_AWS_REGION}}c"]
 


### PR DESCRIPTION
*Issue #, if available:*
EKS version 1.21 is no longer supported.

*Description of changes:*
Update EKS version from 1.21 to 1.25 in KEDA sample application.
I have confirmed it works throughout [the blog post](https://aws.amazon.com/jp/blogs/mt/proactive-autoscaling-of-kubernetes-workloads-with-keda-using-metrics-ingested-into-amazon-cloudwatch/).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
