### PR TITLE
Update wordpress-ecs-fargate.yaml

### DIFF
--- a/CloudFormation/wordpress-ecs-fargate.yaml
+++ b/CloudFormation/wordpress-ecs-fargate.yaml
@@ -29,7 +29,7 @@
     # different AZ to be chosen.
     AZRegions:
       ap-northeast-1:
-        AZs: ["a", "b"]
+        AZs: ["a", "c"]
       ap-northeast-2:
         AZs: ["a", "b"]
       ap-south-1:


### PR DESCRIPTION
*Issue #, if available:*

Error due to AZ ID.
An error occurred due to the Availability Zone ID because ap-northeast-1b is not currently in use.

*Description of changes:*

I change AZ ID of ap-northeast-1 region.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
