### PR TITLE
fix prometheus helm chart installation errors

### DIFF
--- a/fargate-monitoring/prometheus_values.yml
+++ b/fargate-monitoring/prometheus_values.yml
@@ -61,7 +61,7 @@ alertmanager:
   ## Additional alertmanager container environment variable
   ## For instance to add a http_proxy
   ##
-  extraEnv: {}
+  extraEnv: []
 
   ## Additional alertmanager Secret mounts
   # Defines additional mounts with secrets. Secrets must be manually created in the namespace.
@@ -649,10 +649,10 @@ server:
     evaluation_interval: 1m
   ## https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
   ##
-  remoteWrite: {}
+  remoteWrite: []
   ## https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_read
   ##
-  remoteRead: {}
+  remoteRead: []
 
   ## Additional Prometheus server container arguments
   ##


### PR DESCRIPTION
*Issue #, if available:*
When trying to install Prometheus by following [this blog](https://aws.amazon.com/blogs/containers/monitoring-amazon-eks-on-aws-fargate-using-prometheus-and-grafana/), getting errors as below


```
$ helm install prometheus -f prometheus_values.yml   prometheus-community/prometheus --namespace prometheus
coalesce.go:223: warning: destination for prometheus.server.remoteWrite is a table. Ignoring non-table value ([])
coalesce.go:223: warning: destination for prometheus.server.remoteRead is a table. Ignoring non-table value ([])
coalesce.go:175: warning: skipped value for prometheus.alertmanager.extraEnv: Not a table.
coalesce.go:223: warning: destination for prometheus.alertmanager.extraEnv is a table. Ignoring non-table value ([])
coalesce.go:223: warning: destination for prometheus.server.remoteWrite is a table. Ignoring non-table value ([])
coalesce.go:223: warning: destination for prometheus.server.remoteRead is a table. Ignoring non-table value ([])
coalesce.go:175: warning: skipped value for prometheus.alertmanager.extraEnv: Not a table.
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
prometheus:
- server.remoteRead: Invalid type. Expected: array, given: object
- server.remoteWrite: Invalid type. Expected: array, given: object
alertmanager:
- extraEnv: Invalid type. Expected: array, given: object
```



*Description of changes:*
Fixed the values.yaml file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
