### PR TITLE
Updated service type as ClusterIP for Red App

### DIFF
--- a/aws-lb-controller-blog/target-grp-binding/black-app.yaml
+++ b/aws-lb-controller-blog/target-grp-binding/black-app.yaml
@@ -40,7 +40,7 @@ metadata:
   annotations:
     alb.ingress.kubernetes.io/healthcheck-path: /index.html
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: black-app
   ports:


### PR DESCRIPTION
*Issue #, if available:* NodePort is used in the service manifest which is unnecessary as the Ingress is configured using `target type : ip`

*Description of changes:* Changed the service type.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
