### PR TITLE
add comment explaining workaround for 3.4.1.1 check

### DIFF
--- a/cis-bottlerocket-benchmark-eks/bottlerocket-cis-validating-image/validating-script.sh
+++ b/cis-bottlerocket-benchmark-eks/bottlerocket-cis-validating-image/validating-script.sh
@@ -271,6 +271,11 @@ ForwardChain=$(iptables -L | grep "Chain FORWARD" | awk '{print $4}')
 OutputChain=$(iptables -L | grep "Chain OUTPUT" | awk '{print $4}' )
 #echo $OutputChain
 
+# please note, For Kubernetes Bottlerocket variants, the iptables -P FORWARD DROP command will be unconditionally overwritten when the kubelet starts.
+# https://github.com/bottlerocket-os/bottlerocket/blob/52ea5b5c8d788f3e9d7a76e329cd2c766150cf59/packages/kubernetes-1.24/kubelet.service#L13
+# This is because Kubernetes relies on iptables rules to forward connections to any node in the cluster to the correct set of nodes where a nodePort service is running
+# Hence the below condition checks for ACCEPT instead of DROP for the ForwardChain
+
 if [[ $inputChain == "DROP)" ]] && [[ $ForwardChain == "ACCEPT)" ]] && [[ $OutputChain == "DROP)" ]];
 then
     echo "[PASS] $RECOMMENDATION"


### PR DESCRIPTION
This commit adds back a comment explaining the difference in behaviour between the CIS framework and the validation check performed. This is required to clarify difference in results when using the validation script vs the Bottlerocket report API. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
