### PR TITLE
Updated eks version to 1.26 and redis cache version to v9 to mitigate errors as mentioned in description below

### DIFF
--- a/batch-processing-with-k8s/lib/index.ts
+++ b/batch-processing-with-k8s/lib/index.ts
@@ -6,6 +6,7 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { DockerImageAsset } from 'aws-cdk-lib/aws-ecr-assets';
 import * as efs from 'aws-cdk-lib/aws-efs';
 import * as eks from 'aws-cdk-lib/aws-eks';
+import { KubectlV26Layer } from '@aws-cdk/lambda-layer-kubectl-v26';
 import * as elasticcache from 'aws-cdk-lib/aws-elasticache';
 import * as targets from 'aws-cdk-lib/aws-events-targets';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -75,8 +76,9 @@ export class KubernetesFileBatchConstruct extends Construct {
 
     // EKS Cluster
     const cluster = new eks.Cluster(this, this.getId('ekscluster'), {
+      kubectlLayer: new KubectlV26Layer( this, 'kubectl' ),
       vpc: this.vpc,
-      version: eks.KubernetesVersion.V1_19,
+      version: eks.KubernetesVersion.V1_26,
       outputClusterName: true,
       outputConfigCommand: true,
       outputMastersRoleArn: true,

--- a/batch-processing-with-k8s/package.json
+++ b/batch-processing-with-k8s/package.json
@@ -53,9 +53,9 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-
+    "@aws-cdk/lambda-layer-kubectl-v26": "^2.0.1",
     "aws-cdk-lib": "^2.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.0.0" 
   },
   "bundledDependencies": [],
   "keywords": [

--- a/batch-processing-with-k8s/src/file-processor/go.mod
+++ b/batch-processing-with-k8s/src/file-processor/go.mod
@@ -4,6 +4,6 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.38.25
-	github.com/go-redis/redis/v8 v8.8.2
+	github.com/redis/go-redis/v9 v9.3.0
 	github.com/google/uuid v1.2.0
 )

--- a/batch-processing-with-k8s/src/file-processor/go.sum
+++ b/batch-processing-with-k8s/src/file-processor/go.sum
@@ -9,8 +9,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/go-redis/redis/v8 v8.8.2 h1:O/NcHqobw7SEptA0yA6up6spZVFtwE06SXM8rgLtsP8=
-github.com/go-redis/redis/v8 v8.8.2/go.mod h1:F7resOH5Kdug49Otu24RjHWwgK7u9AmtqWMnCV1iP5Y=
+github.com/redis/go-redis/v9 v9.3.0 h1:RiVDjmig62jIWp7Kk4XVLs0hzV6pI3PyTnnL0cnn0u0=
+github.com/redis/go-redis/v9 v9.3.0/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=

--- a/batch-processing-with-k8s/src/file-processor/utils/Redis.go
+++ b/batch-processing-with-k8s/src/file-processor/utils/Redis.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"context"
 	"fmt"
-	"github.com/go-redis/redis/v8"
+	"github.com/redis/go-redis/v9"
 	"os"
 )
 

--- a/batch-processing-with-k8s/src/lambda-map-parallel/go.mod
+++ b/batch-processing-with-k8s/src/lambda-map-parallel/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/aws/aws-lambda-go v1.23.0
-	github.com/go-redis/redis/v8 v8.8.2
+	github.com/redis/go-redis/v9 v9.3.0
 )

--- a/batch-processing-with-k8s/src/lambda-map-parallel/go.sum
+++ b/batch-processing-with-k8s/src/lambda-map-parallel/go.sum
@@ -13,8 +13,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/go-redis/redis/v8 v8.8.2 h1:O/NcHqobw7SEptA0yA6up6spZVFtwE06SXM8rgLtsP8=
-github.com/go-redis/redis/v8 v8.8.2/go.mod h1:F7resOH5Kdug49Otu24RjHWwgK7u9AmtqWMnCV1iP5Y=
+github.com/redis/go-redis/v9 v9.3.0 h1:RiVDjmig62jIWp7Kk4XVLs0hzV6pI3PyTnnL0cnn0u0=
+github.com/redis/go-redis/v9 v9.3.0/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=

--- a/batch-processing-with-k8s/src/lambda-map-parallel/utils/Redis.go
+++ b/batch-processing-with-k8s/src/lambda-map-parallel/utils/Redis.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"context"
 	"fmt"
-	"github.com/go-redis/redis/v8"
+	"github.com/redis/go-redis/v9"
 	"os"
 )
 

--- a/batch-processing-with-k8s/src/split-file/go.mod
+++ b/batch-processing-with-k8s/src/split-file/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.38.25
-	github.com/go-redis/redis/v8 v8.8.2
+	github.com/redis/go-redis/v9 v9.3.0
 )

--- a/batch-processing-with-k8s/src/split-file/go.sum
+++ b/batch-processing-with-k8s/src/split-file/go.sum
@@ -9,8 +9,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/go-redis/redis/v8 v8.8.2 h1:O/NcHqobw7SEptA0yA6up6spZVFtwE06SXM8rgLtsP8=
-github.com/go-redis/redis/v8 v8.8.2/go.mod h1:F7resOH5Kdug49Otu24RjHWwgK7u9AmtqWMnCV1iP5Y=
+github.com/redis/go-redis/v9 v9.3.0 h1:RiVDjmig62jIWp7Kk4XVLs0hzV6pI3PyTnnL0cnn0u0=
+github.com/redis/go-redis/v9 v9.3.0/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=

--- a/batch-processing-with-k8s/src/split-file/utils/Redis.go
+++ b/batch-processing-with-k8s/src/split-file/utils/Redis.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"context"
 	"fmt"
-	"github.com/go-redis/redis/v8"
+	"github.com/redis/go-redis/v9"
 	"os"
 )
 


### PR DESCRIPTION
*Issues:*

* Kubernetes Cluster fails to provision since 1.19 version is not supported any more
* 
{
  "error": "States.Runtime",
  "cause": "Reference path \"$\" must point to array."
}
* "Error while fetching set members got 4 elements in cluster info address, expected 2 or 3"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
