### PR TITLE
fixed "modules/kubernetes-addons/helm-addon" not found

### DIFF
--- a/topology-aware-hints/terraform/main.tf
+++ b/topology-aware-hints/terraform/main.tf
@@ -61,7 +61,7 @@ locals {
 #---------------------------------------------------------------
 
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.27.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.32.1"
 
   cluster_name    = local.cluster_name
   cluster_version = "1.24"
@@ -120,7 +120,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.27.0/modules/kubernetes-addons"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.32.1/modules/kubernetes-addons"
 
   eks_cluster_id       = module.eks_blueprints.eks_cluster_id
   eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint


### PR DESCRIPTION
*Issue #, if available:*

Hitting this bug: 

https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1630

*Description of changes:*

Changes version to v4.32.1 of the blueprint modules to address the issue and fix deployment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
