### PR TITLE
Improve Makefile for Bottlerocket CIS images

### DIFF
--- a/cis-bottlerocket-benchmark-eks/bottlerocket-cis-bootstrap-image/Makefile
+++ b/cis-bottlerocket-benchmark-eks/bottlerocket-cis-bootstrap-image/Makefile
@@ -4,6 +4,7 @@ IMAGE_REPO ?= ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
 IMAGE_NAME ?= ${BOOTSTRAP_ECR_REPO}
 
 IMAGE_TAG ?= latest
+PLATFORM ?= linux/amd64
 
 PWD := $(shell pwd)
 BASE_DIR := $(shell basename $(PWD))
@@ -28,15 +29,15 @@ all: image
 
 image: build-image push-image
 
-build-image: 
-	@echo "Building the docker image: $(IMAGE_NAME):$(IMAGE_TAG) using ${BOOTSTRAP_ECR_REPO}/Dockerfile..."
-	@docker build --no-cache  -t  $(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG) .
+build-image:
+	@echo "Building the container image (platform: $(PLATFORM)): $(IMAGE_NAME):$(IMAGE_TAG) using ${BOOTSTRAP_ECR_REPO}/Dockerfile..."
+	@docker build --platform $(PLATFORM) --no-cache -t $(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG) .
 
 push-image: build-image
-	@echo "Pushing the docker image for $(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG) ..."	
+	@echo "Pushing the container image (platform: $(PLATFORM)) for $(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG) ..."
 	aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin $(IMAGE_REPO)/$(IMAGE_NAME)
 	@docker push $(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
-	
+
 
 ############################################################
 # clean section

--- a/cis-bottlerocket-benchmark-eks/bottlerocket-cis-validating-image/Makefile
+++ b/cis-bottlerocket-benchmark-eks/bottlerocket-cis-validating-image/Makefile
@@ -4,6 +4,7 @@ IMAGE_REPO ?= ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
 IMAGE_NAME ?= ${VALIDATION_ECR_REPO}
 
 IMAGE_TAG ?= latest
+PLATFORM ?= linux/amd64
 
 PWD := $(shell pwd)
 BASE_DIR := $(shell basename $(PWD))
@@ -28,15 +29,15 @@ all: image
 
 image: build-image push-image
 
-build-image: 
-	@echo "Building the docker image: $(IMAGE_NAME):$(IMAGE_TAG) using ${VALIDATION_ECR_REPO}/Dockerfile..."
-	@docker build --no-cache  -t  $(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG) .
+build-image:
+	@echo "Building the container image (platform: $(PLATFORM)): $(IMAGE_NAME):$(IMAGE_TAG) using ${VALIDATION_ECR_REPO}/Dockerfile..."
+	@docker build --platform $(PLATFORM) --no-cache -t $(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG) .
 
 push-image: build-image
-	@echo "Pushing the docker image for $(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG) ..."	
+	@echo "Pushing the container image (platform: $(PLATFORM)) for $(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG) ..."
 	aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin $(IMAGE_REPO)/$(IMAGE_NAME)
 	@docker push $(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
-	
+
 
 ############################################################
 # clean section


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

User's laptop could be `arm64`/`aarch64` system, while the EKS default image would be `linux/amd64`.

With this change, allowing user to decide whether to build images with `linux/amd64` or `linux/arm64`.

### To build image for `amd64` system

```bash
export PLATFORM=linux/amd64
make
```

or

```bash
make
```

### To build image for `arm64` system

```bash
export PLATFORM=linux/arm64
make
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.