### PR TITLE
Upgrade Kubernetes version from 1.26 to 1.33 for Batch Processing on K8s Solution

### DIFF
--- a/batch-processing-with-k8s/lib/index.ts
+++ b/batch-processing-with-k8s/lib/index.ts
@@ -6,7 +6,7 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { DockerImageAsset } from 'aws-cdk-lib/aws-ecr-assets';
 import * as efs from 'aws-cdk-lib/aws-efs';
 import * as eks from 'aws-cdk-lib/aws-eks';
-import { KubectlV26Layer } from '@aws-cdk/lambda-layer-kubectl-v26';
+import { KubectlV33Layer } from '@aws-cdk/lambda-layer-kubectl-v33';
 import * as elasticcache from 'aws-cdk-lib/aws-elasticache';
 import * as targets from 'aws-cdk-lib/aws-events-targets';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -76,9 +76,9 @@ export class KubernetesFileBatchConstruct extends Construct {
 
     // EKS Cluster
     const cluster = new eks.Cluster(this, this.getId('ekscluster'), {
-      kubectlLayer: new KubectlV26Layer( this, 'kubectl' ),
+      kubectlLayer: new KubectlV33Layer( this, 'kubectl' ),
       vpc: this.vpc,
-      version: eks.KubernetesVersion.V1_26,
+      version: eks.KubernetesVersion.V1_33,
       outputClusterName: true,
       outputConfigCommand: true,
       outputMastersRoleArn: true,

--- a/batch-processing-with-k8s/package.json
+++ b/batch-processing-with-k8s/package.json
@@ -53,7 +53,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "@aws-cdk/lambda-layer-kubectl-v26": "^2.0.1",
+    "@aws-cdk/lambda-layer-kubectl-v33": "^2.0.0",
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0" 
   },

--- a/batch-processing-with-k8s/src/file-processor/Dockerfile
+++ b/batch-processing-with-k8s/src/file-processor/Dockerfile
@@ -17,6 +17,7 @@ FROM golang:alpine
 
 # Set necessary environmet variables needed for our image
 RUN apk add --no-cache \
+        aws-cli \
         python3 \
         py3-pip \
         ca-certificates \

--- a/batch-processing-with-k8s/src/single-thread-processor/Dockerfile
+++ b/batch-processing-with-k8s/src/single-thread-processor/Dockerfile
@@ -17,6 +17,7 @@ FROM golang:alpine
 
 # Set necessary environmet variables needed for our image
 RUN apk add --no-cache \
+        aws-cli \
         python3 \
         py3-pip \
         ca-certificates \

--- a/batch-processing-with-k8s/src/split-file/Dockerfile
+++ b/batch-processing-with-k8s/src/split-file/Dockerfile
@@ -17,6 +17,7 @@ FROM golang:alpine
 
 # Set necessary environmet variables needed for our image
 RUN apk add --no-cache \
+        aws-cli \
         python3 \
         py3-pip \
         ca-certificates \


### PR DESCRIPTION
- Update kubectl layer dependency to v33
- Update EKS cluster version to V1_33
- Update kubectl layer import and instantiation

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
