### PR TITLE
fix: add docs CI workflow with mkdocs-material>=9.5.32

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,17 @@
+name: docs
+on:
+  push:
+    branches: [main]
+    paths: ['docs/**', 'mkdocs.yml']
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: pip install "mkdocs-material>=9.5.32"
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
Adds a GitHub Actions workflow to automate documentation builds and deploys with mkdocs-material>=9.5.32 which includes security improvements.

After merge, the workflow will trigger on pushes to docs/ or mkdocs.yml and automatically deploy to GitHub Pages.

No functional changes to documentation content.