### PR TITLE
fix(chart): preserve newline between per-agent manifests

### DIFF
--- a/multi-agent-fsi-blog/apps/financial-services/gitops/financial-services-stack/templates/agents-deployment.yaml
+++ b/multi-agent-fsi-blog/apps/financial-services/gitops/financial-services-stack/templates/agents-deployment.yaml
@@ -47,7 +47,7 @@ Per-agent outputs Secret name. Each agent reads only its own Secret,
 which is populated by the agent-scoped Terraform CR in wave 0.
 */}}
 {{- range $agent := .Values.agents }}
-{{- $outputsSecret := printf "%s-%s-outputs-%s" $.Values.projectName $agent.name $.Values.version -}}
+{{ $outputsSecret := printf "%s-%s-outputs-%s" $.Values.projectName $agent.name $.Values.version -}}
 {{- $sa := printf "%s-sa" $agent.name -}}
 ---
 apiVersion: v1


### PR DESCRIPTION
## Summary

- Single-character template fix in `agents-deployment.yaml`: change `{{-` to `{{ ` on the `$outputsSecret` assignment so the preceding newline is preserved across `range` iterations.
- Without this fix, 3 of 4 per-agent Deployments never reach the cluster — ArgoCD sync fails, only `financial-advisor` + `financial-tools-mcp` + `market-data` pods come up.

## Symptom

ArgoCD sync fails with:

```
failed to create typed patch object (financial-services/market-data-sa; /v1, Kind=ServiceAccount): .spec: field not declared in schema
failed to create typed patch object (financial-services/portfolio-analyst-sa; /v1, Kind=ServiceAccount): .spec: field not declared in schema
failed to create typed patch object (financial-services/risk-assessment-sa; /v1, Kind=ServiceAccount): .spec: field not declared in schema
```

## Root cause

The per-agent `range` loop in `agents-deployment.yaml` uses `{{-` on line 50, which trims the newline from the previous iteration. Rendered output fuses the trailing `periodSeconds: 15` of each Deployment with the next `---`:

```
            periodSeconds: 15---
apiVersion: v1
kind: ServiceAccount
  name: portfolio-analyst-sa
...
```

Helm's multi-doc YAML splitter then merges the Deployment with the following ServiceAccount into one document — so the next agent's ServiceAccount ends up with the previous agent's Deployment `.spec`, which the Kubernetes schema rejects.

The first agent in the `.Values.agents` list (`financial-advisor`) renders correctly because there's no previous iteration to collide with. The last agent (`market-data`) also renders correctly because the `{{- end }}` after the loop closes cleanly. Everyone in the middle breaks.

## Fix

```diff
 {{- range \$agent := .Values.agents }}
-{{- \$outputsSecret := printf \"%s-%s-outputs-%s\" \$.Values.projectName \$agent.name \$.Values.version -}}
+{{ \$outputsSecret := printf \"%s-%s-outputs-%s\" \$.Values.projectName \$agent.name \$.Values.version -}}
 {{- \$sa := printf \"%s-sa\" \$agent.name -}}
 ---
```

Dropping the left-trim keeps the newline between iterations so every `---` lands on its own line.

## Test plan

- [x] \`helm template\` the chart — \`grep 'periodSeconds: 15---'\` now returns 0 matches (was 3 before the fix).
- [x] All 5 Deployments + 6 ServiceAccounts render as distinct YAML documents.
- [x] Manually applied the fixed render to a live \`finops-agents\` cluster — all 4 agents reached \`Running\`, all 5 \`AgentgatewayPolicy\` objects \`ATTACHED=True\`, 7/7 README authn/authz matrix passes (401/401/401/200/403/403/200), full demo query returns the portfolio synthesis from the multi-agent chain end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)