### PR TITLE
fix(otel-blog): bump ArgoCD Redis to 8.6.6-alpine for openssl CVE fix

### DIFF
--- a/otel-agent-observability-patterns-blog/terraform/bootstrap/main.tf
+++ b/otel-agent-observability-patterns-blog/terraform/bootstrap/main.tf
@@ -68,9 +68,12 @@ resource "helm_release" "argocd" {
     value = "public.ecr.aws/docker/library/redis"
   }
 
+  # 8.6.6-alpine rebuilds on alpine-minirootfs-3.23.5, which ships
+  # openssl 3.5.8-r0 — fixing CVE-2026-14456, CVE-2026-14457, CVE-2026-18798
+  # (High) present in the openssl 3.5.7-r0 base of the earlier 8.6.4-alpine build.
   set {
     name  = "redis.image.tag"
-    value = "8.6.4-alpine"
+    value = "8.6.6-alpine"
   }
 }
 


### PR DESCRIPTION
The bootstrap Terraform pins the ArgoCD Redis image to redis:8.6.4-alpine, whose alpine-minirootfs-3.23 base carries openssl 3.5.7-r0. That build is flagged by Amazon Inspector for three High-severity OpenSSL CVEs:

  - CVE-2026-14456
  - CVE-2026-14457
  - CVE-2026-18798

Bump the pin to redis:8.6.6-alpine. Verified via the public ECR registry that this tag rebuilds on alpine-minirootfs-3.23.5, whose main repo ships openssl 3.5.8-r0 (the fixed version per the Alpine Security Tracker). This is a same-minor patch bump within the OSS-licensed Redis 8.6 line, so no behavioral change to ArgoCD's Redis dependency.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
